### PR TITLE
doc: Fixed small typo in response format schema in installation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ completion = client.chat.completions.create(
     response_format={
         "type": "json_schema",
         "json_schema": {
-            "name": "answear",
+            "name": "answer",
             "schema": {
                 "type": "object",
                 "properties": {


### PR DESCRIPTION
There was a typo in the response format JSON schema name in the documentation