### PR TITLE
Update helpers.py

### DIFF
--- a/structured_logprobs/helpers.py
+++ b/structured_logprobs/helpers.py
@@ -23,10 +23,13 @@ json_grammar = r"""
           | array
           | string
           | SIGNED_NUMBER -> number    #'-> number' specifies an alias for the rule
-          | "true"
-          | "false"
-          | "null"
+          | true
+          | false
+          | null
 
+    true: "true"
+    false: "false"
+    null: "null"
     array  : "[" [value ("," value)*] "]"
     object : "{" [pair ("," pair)*] "}"
     pair   : key ":" value


### PR DESCRIPTION
Strings like {"verdict":false} were being parsed as {"verdict":None} instead of {"verdict":False}. The change fixes this bug.